### PR TITLE
Fix/step artifacts attachment

### DIFF
--- a/vedro-allure-reporter.code-workspace
+++ b/vedro-allure-reporter.code-workspace
@@ -1,0 +1,8 @@
+{
+	"folders": [
+		{
+			"path": "."
+		}
+	],
+	"settings": {}
+}


### PR DESCRIPTION
Refactor late step artifacts attachment: optimize performance and add tests

- Optimize performance by creating allure_steps_by_name dictionary once
  instead of recreating it for each scenario_result
- Remove unused test_result parameter from _process_late_step_artifacts
- Add comprehensive test coverage for late step artifacts functionality
- Fix type annotations and improve code quality
- Remove redundant comments and improve code readability