### PR TITLE
Add support for reporting skipped scenarios in Allure reports

### DIFF
--- a/tests/test_allure_reporter_skipped.py
+++ b/tests/test_allure_reporter_skipped.py
@@ -1,0 +1,122 @@
+import pytest
+from allure_commons.logger import AllureMemoryLogger
+from allure_commons.model2 import Status
+from baby_steps import given, then, when
+from vedro.core import Dispatcher
+from vedro.events import ScenarioReportedEvent
+from vedro.plugins.director import DirectorPlugin
+
+import vedro_allure_reporter
+from vedro_allure_reporter import AllureReporter, AllureReporterPlugin
+
+from ._utils import (
+    choose_reporter,
+    director,
+    dispatcher,
+    fire_arg_parsed_event,
+    logger,
+    logger_,
+    logger_factory_,
+    make_aggregated_result,
+    make_scenario_result,
+    patch_uuid,
+    plugin_manager_,
+)
+
+__all__ = ("dispatcher", "director", "plugin_manager_", "logger_", "logger_factory_", "logger")
+
+
+@pytest.fixture()
+def reporter(dispatcher: Dispatcher, logger: AllureMemoryLogger) -> AllureReporterPlugin:
+    reporter = AllureReporterPlugin(vedro_allure_reporter.AllureReporter,
+                                    logger_factory=lambda *args, **kwargs: logger)
+    reporter.subscribe(dispatcher)
+    return reporter
+
+
+async def test_report_skipped_scenario_default(*, dispatcher: Dispatcher,
+                                               director: DirectorPlugin,
+                                               reporter: AllureReporterPlugin,
+                                               logger: AllureMemoryLogger):
+    with given:
+        await choose_reporter(dispatcher, director, reporter)
+        await fire_arg_parsed_event(dispatcher)
+
+        scenario_result = make_scenario_result(subject="Skipped scenario")
+        scenario_result.mark_skipped().set_started_at(1.0).set_ended_at(1.0)
+
+        aggregated_result = make_aggregated_result(scenario_result)
+        event = ScenarioReportedEvent(aggregated_result)
+
+    with when:
+        with patch_uuid() as test_uuid:
+            await dispatcher.fire(event)
+
+    with then:
+        assert len(logger.test_cases) == 1
+        test_case = logger.test_cases[0]
+        assert test_case["uuid"] == test_uuid
+        assert test_case["name"] == "Skipped scenario"
+        assert test_case["status"] == Status.SKIPPED
+        assert "steps" not in test_case or len(test_case.get("steps", [])) == 0
+
+
+async def test_report_skipped_scenario_disabled(*, dispatcher: Dispatcher,
+                                                director: DirectorPlugin,
+                                                logger: AllureMemoryLogger):
+    with given:
+        # Create reporter with report_skipped_scenarios=False
+        class AllureReporterNoSkipped(AllureReporter):
+            report_skipped_scenarios = False
+
+        reporter = AllureReporterPlugin(AllureReporterNoSkipped,
+                                        logger_factory=lambda *args, **kwargs: logger)
+        reporter.subscribe(dispatcher)
+
+        await choose_reporter(dispatcher, director, reporter)
+        await fire_arg_parsed_event(dispatcher)
+
+        scenario_result = make_scenario_result(subject="Skipped scenario")
+        scenario_result.mark_skipped().set_started_at(1.0).set_ended_at(1.0)
+
+        aggregated_result = make_aggregated_result(scenario_result)
+        event = ScenarioReportedEvent(aggregated_result)
+
+    with when:
+        await dispatcher.fire(event)
+
+    with then:
+        assert len(logger.test_cases) == 0
+
+
+async def test_report_skipped_scenario_with_labels(*, dispatcher: Dispatcher,
+                                                   director: DirectorPlugin,
+                                                   reporter: AllureReporterPlugin,
+                                                   logger: AllureMemoryLogger):
+    with given:
+        from vedro_allure_reporter import AllureLabel
+
+        await choose_reporter(dispatcher, director, reporter)
+        await fire_arg_parsed_event(dispatcher)
+
+        labels = (AllureLabel("feature", "TEST_FEATURE"), AllureLabel("story", "TEST_STORY"))
+        scenario_result = make_scenario_result(subject="Skipped with labels", labels=labels)
+        scenario_result.mark_skipped().set_started_at(1.0).set_ended_at(1.0)
+
+        aggregated_result = make_aggregated_result(scenario_result)
+        event = ScenarioReportedEvent(aggregated_result)
+
+    with when:
+        with patch_uuid():
+            await dispatcher.fire(event)
+
+    with then:
+        assert len(logger.test_cases) == 1
+        test_case = logger.test_cases[0]
+
+        assert test_case["status"] == Status.SKIPPED
+
+        # Check that labels are present
+        label_dict = {label["name"]: label["value"] for label in test_case["labels"]}
+        assert label_dict["feature"] == "TEST_FEATURE"
+        assert label_dict["story"] == "TEST_STORY"

--- a/vedro_allure_reporter/_allure_reporter.py
+++ b/vedro_allure_reporter/_allure_reporter.py
@@ -525,12 +525,6 @@ class AllureReporterPlugin(Reporter):
         test_result.stop = self._to_seconds(scenario_result.ended_at or time())
         test_result.labels.extend(self._create_labels(scenario_result.scenario))
 
-        # Add skip reason as status details if available
-        for step_result in scenario_result.step_results:
-            if step_result.exc_info:
-                test_result.statusDetails = self._create_status_details(step_result.exc_info)
-                break
-
         # Schedule and close the test immediately
         self._allure_commons_reporter.schedule_test(test_uuid, test_result)  # type: ignore
         self._allure_commons_reporter.close_test(test_uuid)  # type: ignore

--- a/vedro_allure_reporter/_allure_reporter.py
+++ b/vedro_allure_reporter/_allure_reporter.py
@@ -76,6 +76,7 @@ class AllureReporterPlugin(Reporter):
         self._config_labels = config.labels
         self._clean_report_dir = config.clean_report_dir
         self._report_rescheduled_scenarios = config.report_rescheduled_scenarios
+        self._report_skipped_scenarios = config.report_skipped_scenarios
         self._allure_labels: Union[str, None] = None
         self._allure_rerunner = AllureRerunnerPlugin(AllureRerunner)
         self._allure_commons_reporter = AllureCommonsReporter()  # type: ignore[no-untyped-call]
@@ -472,7 +473,10 @@ class AllureReporterPlugin(Reporter):
         :param scenario_result: The ScenarioResult object containing scenario data.
         :param status: The status of the scenario (PASSED, FAILED, SKIPPED).
         """
+        # Handle skipped scenarios that were never run
         if not self._current_test_uuid:
+            if status == Status.SKIPPED and self._report_skipped_scenarios:
+                self._report_skipped_scenario(scenario_result, status)
             return
         # Update test result with final status and metadata
         test_result = self._allure_commons_reporter.get_test(  # type: ignore
@@ -498,6 +502,38 @@ class AllureReporterPlugin(Reporter):
         # Close test
         self._allure_commons_reporter.close_test(self._current_test_uuid)  # type: ignore
         self._current_test_uuid = None
+
+    def _report_skipped_scenario(self, scenario_result: ScenarioResult, status: str) -> None:
+        """
+        Report a skipped scenario that was never run (e.g., @vedro.skip()).
+
+        This method creates a minimal test result for scenarios that were skipped before
+        execution. It includes the scenario name, labels, and skip reason if available.
+
+        :param scenario_result: The ScenarioResult object containing scenario data.
+        :param status: The status of the scenario (should be SKIPPED).
+        """
+        test_uuid = self._get_uuid4()
+        test_result = TestResult()
+        test_result.uuid = test_uuid
+        test_result.name = scenario_result.scenario.subject
+        test_result.fullName = scenario_result.scenario.unique_id
+        test_result.historyId = self._get_scenario_unique_id(scenario_result.scenario)
+        test_result.testCaseId = self._get_scenario_unique_id(scenario_result.scenario)
+        test_result.status = status
+        test_result.start = self._to_seconds(scenario_result.started_at or time())
+        test_result.stop = self._to_seconds(scenario_result.ended_at or time())
+        test_result.labels.extend(self._create_labels(scenario_result.scenario))
+
+        # Add skip reason as status details if available
+        for step_result in scenario_result.step_results:
+            if step_result.exc_info:
+                test_result.statusDetails = self._create_status_details(step_result.exc_info)
+                break
+
+        # Schedule and close the test immediately
+        self._allure_commons_reporter.schedule_test(test_uuid, test_result)  # type: ignore
+        self._allure_commons_reporter.close_test(test_uuid)  # type: ignore
 
     def _create_status_details(self, exc_info: ExcInfo) -> StatusDetails:
         """
@@ -677,3 +713,7 @@ class AllureReporter(PluginConfig):
     # represented, providing visibility into the scenario's intermediate attempts.
     # If False, only the aggregated final result is reported.
     report_rescheduled_scenarios: bool = False
+
+    # If True, includes scenarios that were skipped before execution (e.g., via @vedro.skip())
+    # in the Allure report with SKIPPED status. If False, skipped scenarios are not reported.
+    report_skipped_scenarios: bool = True


### PR DESCRIPTION
- Introduced a new configuration option `report_skipped_scenarios` to control the reporting of scenarios that were skipped before execution.
- Implemented the `_report_skipped_scenario` method to create minimal test results for skipped scenarios, including scenario name, labels, and skip reason if available.
- Updated the handling of scenario results to report skipped scenarios when the new option is enabled.